### PR TITLE
put_bytes(container) via region.copy

### DIFF
--- a/include/mem/mem.h
+++ b/include/mem/mem.h
@@ -113,6 +113,14 @@ namespace mem
         typename std::enable_if<!std::is_reference<T>::value, typename std::add_lvalue_reference<T>::type>::type
         rcast() & noexcept;
 
+        template <typename Container>
+        constexpr pointer put_bytes(const Container& obj) const noexcept {
+            using value_t = typename Container::value_type;
+            constexpr auto size_e  = sizeof uint8_t;
+            region(*this, size_e * std::size(obj)).copy(std::data(obj));
+            return *this;
+        }
+
         template <typename Func>
         constexpr pointer and_then(Func&& func) const;
 

--- a/include/mem/mem.h
+++ b/include/mem/mem.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <type_traits>
 #include <utility>
+#include <array>
 
 namespace mem
 {
@@ -116,7 +117,7 @@ namespace mem
         template <typename Container>
         constexpr pointer put_bytes(const Container& obj) const noexcept {
             using value_t = typename Container::value_type;
-            constexpr auto size_e  = sizeof uint8_t;
+            constexpr auto size_e  = sizeof value_t;
             region(*this, size_e * std::size(obj)).copy(std::data(obj));
             return *this;
         }

--- a/include/mem/mem.h
+++ b/include/mem/mem.h
@@ -117,8 +117,8 @@ namespace mem
         template <typename Container>
         constexpr pointer put_bytes(const Container& obj) const noexcept {
             using value_t = typename Container::value_type;
-            constexpr auto size_e  = sizeof value_t;
-            region(*this, size_e * std::size(obj)).copy(std::data(obj));
+            constexpr auto size_e  = sizeof(value_t);
+            region(*this, size_e * obj.size()).copy(obj.data());
             return *this;
         }
 


### PR DESCRIPTION
add helper method to mem::pointer to write arbitrary container to memory, (ida: ida_bytes.put_bytes)

```cpp
mem::scan(mem::pattern("01 b2 2a aa"), r)
    .and_then([&](auto m) {
        m.sub(9).rip(4).put_bytes(mem::pattern("b8 01 00 00 00 c3").bytes());
    });
``` 