### PR TITLE
Add preliminary aarch64 support for pattern-bench

### DIFF
--- a/include/mem/arch.h
+++ b/include/mem/arch.h
@@ -39,22 +39,22 @@ namespace mem
     {
         return __rdtsc();
     }
+#endif
 
     MEM_STRONG_INLINE unsigned int bsf(unsigned int x) noexcept
     {
-#    if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4)))
+#if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4)))
         return static_cast<unsigned int>(__builtin_ctz(x));
-#    elif defined(_MSC_VER)
+#elif defined(_MSC_VER)
         unsigned long result;
         _BitScanForward(&result, static_cast<unsigned long>(x));
         return static_cast<unsigned int>(result);
-#    else
+#else
         unsigned int result;
         asm("bsf %1, %0" : "=r"(result) : "rm"(x));
         return result;
-#    endif
-    }
 #endif
+    }
 } // namespace mem
 
 #endif // MEM_ARCH_BRICK_H

--- a/include/mem/defines.h
+++ b/include/mem/defines.h
@@ -24,31 +24,37 @@
 #    define MEM_ARCH_X86_64
 #elif defined(__i386) || defined(_M_IX86)
 #    define MEM_ARCH_X86
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#    define MEM_ARCH_AARCH64
 #endif
 
-#if defined(__AVX2__)
+#if defined(__APPLE__) && !defined(__unix__)
+#    define __unix__
+#endif
+
+#if !defined(MEM_SIMD_AVX2) && defined(__AVX2__)
 #    define MEM_SIMD_AVX2
 #endif
 
-#if defined(__AVX__) || defined(MEM_SIMD_AVX2)
+#if !defined(MEM_SIMD_AVX) && (defined(__AVX__) || defined(MEM_SIMD_AVX2))
 #    define MEM_SIMD_AVX
 #endif
 
-#if defined(__SSSE3__) || defined(MEM_SIMD_AVX)
+#if !defined(MEM_SIMD_SSSE3) && (defined(__SSSE3__) || defined(MEM_SIMD_AVX))
 #    define MEM_SIMD_SSSE3
 #endif
 
-#if defined(__SSE3__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2)) || \
-    defined(MEM_SIMD_SSSE3)
+#if !defined(MEM_SIMD_SSE3) && (defined(__SSE3__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2)) || \
+    defined(MEM_SIMD_SSSE3))
 #    define MEM_SIMD_SSE3
 #endif
 
-#if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2)) || \
-    defined(MEM_SIMD_SSE3)
+#if !defined(MEM_SIMD_SSE2) && (defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2)) || \
+    defined(MEM_SIMD_SSE3))
 #    define MEM_SIMD_SSE2
 #endif
 
-#if defined(__SSE__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 1)) || defined(MEM_SIMD_SSE2)
+#if !defined(MEM_SIMD_SSE) && (defined(__SSE__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 1)) || defined(MEM_SIMD_SSE2))
 #    define MEM_SIMD_SSE
 #endif
 


### PR DESCRIPTION
This allows overriding `MEM_SIMD_XXX` and use https://github.com/simd-everywhere/simde to test on aarch64

For reference, the (draft) commit that uses this: https://github.com/mrexodia/pattern-bench/commit/78d4f770e532132298932476ea03bda8e4692277